### PR TITLE
Update GPIO pin numbering offset to account for gpiochip base

### DIFF
--- a/pin.sh
+++ b/pin.sh
@@ -7,7 +7,7 @@ if [ $# != 0 ]
 then
 
     # Set up our argument variables
-    arg1="$1"
+    arg1="$((512+$1))"
     arg2="$2"
 
     # If the gpio pin was not previously set up


### PR DESCRIPTION
An update to Raspberry Pi OS changed the base number of the GPIO controller. This patch should account for it by adding 512 (the base number of the controller) to the GPIO pin number.